### PR TITLE
Fixing setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ setup(
     description="Hfinger - fingerprinting HTTP requests stored in pcap files",
     author="Piotr Bialczak",
     author_email="piotrb@cert.pl",
-    packages=["hfinger"],
+    packages=["hfinger", "hfinger.configs"],
+    package_data={"hfinger": ["configs/*.json", "configs/*.txt"]},
     install_requires=["fnvhash", "python-magic"],
     zip_safe=False,
 )


### PR DESCRIPTION
Module `hfinger.configs` is not installed after `python3 setup.py install` so any import raises `ModuleNotFoundError`.

Config files (`*.json`, `*.txt`) are not installed too.

    $ git clone https://github.com/CERT-Polska/hfinger.git
    Cloning into 'hfinger'...
    remote: Enumerating objects: 22, done.
    remote: Counting objects: 100% (22/22), done.
    remote: Compressing objects: 100% (20/20), done.
    remote: Total 22 (delta 0), reused 22 (delta 0), pack-reused 0
    Unpacking objects: 100% (22/22), done.
    $ cd hfinger/
    $ python3 setup.py install
    running install
    running bdist_egg
    running egg_info
    creating hfinger.egg-info
    ...
    Finished processing dependencies for hfinger==0.1.0
    $ cd ..
    $ python3 -c "import hfinger.hreader"
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/local/lib/python3.8/site-packages/hfinger-0.1.0-py3.8.egg/hfinger/hreader.py", line 3, in <module>
        import hfinger.hfinger_core
      File "/usr/local/lib/python3.8/site-packages/hfinger-0.1.0-py3.8.egg/hfinger/hfinger_core.py", line 6, in <module>
        from hfinger.configs.configs import AEVAL, CONNVAL, CONTENC, CACHECONT, TE, ACCPTCHAR, METHODS
    ModuleNotFoundError: No module named 'hfinger.configs'

If you prefer to add `.gitignore` in different PR just tell.
